### PR TITLE
splot 1.1.3 [test geopandas 1.0.1]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/951d030

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/7bdd97e
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/72affa5
+  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/5b6a3b7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,6 @@
 channels:
   - https://staging.continuum.io/prefect/fs/libpysal-feedstock/pr6/f1cefa4
   - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/72affa5
-  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/5b6a3b7
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/e8dafb8
+  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/be2e3f9
+  - https://staging.continuum.io/prefect/fs/pyogrio-feedstock/pr1/2f9ed2a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,6 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libpysal-feedstock/pr6/f1cefa4
-  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/e8dafb8
-  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/be2e3f9
-  - https://staging.continuum.io/prefect/fs/pyogrio-feedstock/pr1/2f9ed2a
+  - https://staging.continuum.io/prefect/fs/libpysal-feedstock/pr6/6c51275
+  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/0b5fc8c
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/e1c714c
+  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/f50eb98
+  - https://staging.continuum.io/prefect/fs/pyogrio-feedstock/pr1/a8c62fe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/951d030
+  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/7bdd97e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libpysal-feedstock/pr6/6c51275
-  - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/0b5fc8c
-  - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/e1c714c
-  - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/f50eb98
-  - https://staging.continuum.io/prefect/fs/pyogrio-feedstock/pr1/a8c62fe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,5 @@
 channels:
+  - https://staging.continuum.io/prefect/fs/libpysal-feedstock/pr6/f1cefa4
   - https://staging.continuum.io/prefect/fs/geopandas-feedstock/pr11/5723099
   - https://staging.continuum.io/prefect/fs/esda-feedstock/pr3/72affa5
   - https://staging.continuum.io/prefect/fs/spreg-feedstock/pr2/5b6a3b7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - python
     - numpy
     - geopandas >=0.4.0
+    - geopandas <1.0.0a0  # [py<310]
     # matplotlib : register_cmap and get_cmap function were deprecated
     # in Matplotlib 3.7 and removed two minor releases later (fails with
     # 3.9.2, succeeds with 3.8.4)
@@ -48,6 +49,8 @@ requirements:
     - descartes
     # ipywidgets used in the source code
     - ipywidgets
+  run_constrained:
+    - fiona <1.9  # [py<310]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,27 +8,45 @@ package:
 source:
   url: https://pypi.io/packages/source/s/splot/splot-{{ version }}.tar.gz
   sha256: 7be9557cd3c6c0374e07c2a149e1330318d22d6ecb420f70f1a0dbad9b3187fd
+  patches:
+    - patches/0001-fix-bokeh-axis-visible-to-false.patch
+    - patches/0002-import-abc-from-collections_abc.patch  # [py>39]
+    - patches/0003-either-c-or-color-for-dynamic_lisa_vectors.patch
 
 build:
-  noarch: python
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  # skip s390x: no libgdal
+  skip: True  # [s390x]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch       # [not win]
+    - m2-patch    # [win]
   host:
-    - python >=3
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
     - numpy
     - geopandas >=0.4.0
-    - matplotlib-base
+    # matplotlib : register_cmap and get_cmap function were deprecated
+    # in Matplotlib 3.7 and removed two minor releases later (fails with
+    # 3.9.2, succeeds with 3.8.4)
+    - matplotlib-base <3.9.0a0
     - seaborn
+    # libpysal: for py39 the version 4.5.1 will be used
+    #           while >=4.10 is available only for py>39
     - libpysal
+    - libpysal >=4.10  # [py>39]
     - mapclassify
     - esda
     - spreg
     - giddy
+    - descartes
+    # ipywidgets used in the source code
     - ipywidgets
 
 test:
@@ -38,21 +56,34 @@ test:
     - splot.giddy
     - splot.libpysal
     - splot.mapping
+  requires:
+    - pip
+    - pytest
+    - nose
+    # bokeh: AttributeError: unexpected attribute 'plot_width'
+    - bokeh <3.0.0a0
+  source_files:
+    - splot/tests
+  commands:
+    - pip check
+    # check that pip gets the correct version 
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # skip test_moran_scatterplot, because Guerry.shp is not a built in libpysal example
+    - pytest -vv -k "not (test_moran_ or test_plot_moran)"
 
 about:
-  home: http://pysal.org
+  home: https://pysal.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: Lightweight plotting and mapping to facilitate spatial analysis with PySAL
-
   description: |
     splot connects spatial analysis done in PySAL to different popular visualization
     toolkits like matplotlib. The splot package allows you to create both static plots
     ready for publication and interactive visualizations for quick iteration and
     spatial data exploration. The primary goal of splot is to enable you to visualize
     popular PySAL objects and gives you different views on your spatial analysis workflow.
-  doc_url: https://splot.readthedocs.io/en/latest/
+  doc_url: https://splot.readthedocs.io
   dev_url: https://github.com/pysal/splot
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ source:
 build:
   number: 1
   # skip s390x: no libgdal
-  skip: True  # [s390x]
+  # skip py>311: no giddy
+  skip: True  # [s390x or py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - libpysal
     - libpysal >=4.10  # [py>39]
     - mapclassify
-    - esda
+    - esda >=2.5.1
     - spreg
     - giddy
     - descartes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,15 @@ requirements:
   run_constrained:
     - fiona <1.9  # [py<310]
 
+{% set tests_to_skip = "" %}
+# skip test_moran_scatterplot, because Guerry.shp is not a built in libpysal example
+{% set tests_to_skip = tests_to_skip + "test_moran_ or test_plot_moran" %}
+# skip tests for py39 because libpysal is available on an older version
+# and tests fail with TypeError: 'MultiPolygon' object is not iterable 
+{% set tests_to_skip = tests_to_skip + " or test_dynamic_lisa" %}  # [py<310]
+{% set tests_to_skip = tests_to_skip + " or test_plot_local_autocorrelation" %}  # [py<310]
+{% set tests_to_skip = tests_to_skip + " or test_plot_spatial_weights" %}  # [py<310]
+
 test:
   imports:
     - splot
@@ -64,15 +73,15 @@ test:
     - pytest
     - nose
     # bokeh: AttributeError: unexpected attribute 'plot_width'
-    - bokeh <3.0.0a0
+    - bokeh <3.0.0a0  # [py<312]
+    - bokeh           # [py>=312]
   source_files:
     - splot/tests
   commands:
     - pip check
     # check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    # skip test_moran_scatterplot, because Guerry.shp is not a built in libpysal example
-    - pytest -vv -k "not (test_moran_ or test_plot_moran)"
+    - pytest -vv -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://pysal.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,13 +76,11 @@ test:
     # bokeh: AttributeError: unexpected attribute 'plot_width'
     - bokeh <3.0.0a0  # [py<312]
     - bokeh           # [py>=312]
-  source_files:
-    - splot/tests
   commands:
     - pip check
     # check that pip gets the correct version 
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -vv -k "not ({{ tests_to_skip }})"
+    - pytest -vv --pyargs splot -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://pysal.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/patches/0001-fix-bokeh-axis-visible-to-false.patch
+++ b/recipe/patches/0001-fix-bokeh-axis-visible-to-false.patch
@@ -1,0 +1,34 @@
+From 8f0cfce3337c5ae49a6004d058dcf8b4b2ef4861 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Mon, 10 Feb 2025 13:51:31 +0100
+Subject: [PATCH] fix bokeh axis visible to False
+
+---
+ splot/_viz_bokeh.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/splot/_viz_bokeh.py b/splot/_viz_bokeh.py
+index 50ac5bb..8e72c23 100644
+--- a/splot/_viz_bokeh.py
++++ b/splot/_viz_bokeh.py
+@@ -150,7 +150,7 @@ def _plot_choropleth_fig(geo_source, attribute, bin_labels, bounds,
+     # change layout
+     fig.xgrid.grid_line_color = None
+     fig.ygrid.grid_line_color = None
+-    fig.axis.visible = None
++    fig.axis.visible = False
+     return fig
+ 
+ 
+@@ -261,7 +261,7 @@ def _lisa_cluster_fig(geo_source, moran_loc, cluster_labels, colors5,
+     # change layout
+     fig.xgrid.grid_line_color = None
+     fig.ygrid.grid_line_color = None
+-    fig.axis.visible = None
++    fig.axis.visible = False
+     return fig
+ 
+ 
+-- 
+2.39.1
+

--- a/recipe/patches/0002-import-abc-from-collections_abc.patch
+++ b/recipe/patches/0002-import-abc-from-collections_abc.patch
@@ -1,0 +1,32 @@
+From 10fbce92917f79e8d62ccd2e48601c4ef2c8765a Mon Sep 17 00:00:00 2001
+From: Karthikeyan Singaravelan <tir.karthi@gmail.com>
+Date: Sat, 26 Mar 2022 21:08:21 +0530
+Subject: [PATCH] Import ABC from collections.abc for Python 3.10
+ compatibility. (#150)
+
+---
+ splot/_viz_value_by_alpha_mpl.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/splot/_viz_value_by_alpha_mpl.py b/splot/_viz_value_by_alpha_mpl.py
+index 63fa64be..e0640028 100644
+--- a/splot/_viz_value_by_alpha_mpl.py
++++ b/splot/_viz_value_by_alpha_mpl.py
+@@ -1,7 +1,7 @@
+ import matplotlib.pyplot as plt
+ from matplotlib import colors
+ from matplotlib import patches
+-import collections
++import collections.abc
+ import matplotlib.cm as cm
+ import mapclassify as classify
+ import numpy as np
+@@ -89,7 +89,7 @@ def value_by_alpha_cmap(x, y, cmap='GnBu', revert_alpha=False, divergent=False):
+     # option for cmap or colorlist input
+     if isinstance(cmap, str):
+         cmap = cm.get_cmap(cmap)
+-    elif isinstance(cmap, collections.Sequence):
++    elif isinstance(cmap, collections.abc.Sequence):
+         cmap = colors.LinearSegmentedColormap.from_list('newmap', cmap)
+ 
+     rgba = cmap((x - x.min()) / (x.max() - x.min()))

--- a/recipe/patches/0003-either-c-or-color-for-dynamic_lisa_vectors.patch
+++ b/recipe/patches/0003-either-c-or-color-for-dynamic_lisa_vectors.patch
@@ -1,0 +1,66 @@
+From 767e7c31a29c5267ce847526298f52df9eabd05c Mon Sep 17 00:00:00 2001
+From: Stefanie Lumnitz <stefanie.lumnitz@gmail.com>
+Date: Mon, 21 Dec 2020 16:07:41 -0800
+Subject: [PATCH] [MAINT] enforce either `c` or `color` are passed in
+ `dynamic_lisa_vectors()`
+
+---
+ splot/_viz_giddy_mpl.py | 31 +++++++++++++++++++++----------
+ 1 file changed, 21 insertions(+), 10 deletions(-)
+
+diff --git a/splot/_viz_giddy_mpl.py b/splot/_viz_giddy_mpl.py
+index 75ec3eb4..e4f2dca7 100644
+--- a/splot/_viz_giddy_mpl.py
++++ b/splot/_viz_giddy_mpl.py
+@@ -290,12 +290,19 @@ def dynamic_lisa_rose(rose, attribute=None, ax=None, **kwargs):
+ def _add_arrow(line, position=None, direction='right', size=15, color=None):
+     """
+     add an arrow to a line.
+-
+-    line:       Line2D object
+-    position:   x-position of the arrow. If None, mean of xdata is taken
+-    direction:  'left' or 'right'
+-    size:       size of the arrow in fontsize points
+-    color:      if None, line color is taken.
++    
++    Parameters
++    ----------
++    line:
++        Line2D object
++    position: float
++        x-position of the arrow. If None, mean of xdata is taken
++    direction: str
++        'left' or 'right'
++    size: int
++        size of the arrow in fontsize points
++    color: str
++        if None, line color is taken.
+ 
+     """
+     if color is None:
+@@ -384,7 +391,7 @@ def dynamic_lisa_vectors(rose, ax=None,
+ 
+     customize plot
+ 
+-    >>> dynamic_lisa_vectors(rose, arrows=False, c='r')
++    >>> dynamic_lisa_vectors(rose, arrows=False, color='r')
+     >>> plt.show()
+ 
+     """
+@@ -398,9 +405,13 @@ def dynamic_lisa_vectors(rose, ax=None,
+ 
+     xlim = [rose.Y.min(), rose.Y.max()]
+     ylim = [rose.wY.min(), rose.wY.max()]
+-
+-    color = kwargs.pop('color', 'b')
+-    can_insert_colorbar = False
++    
++    if 'c' in kwargs.keys():
++        color = kwargs.pop('c', 'b')
++        can_insert_colorbar = False
++    else:
++        color = kwargs.pop('color', 'b')
++        can_insert_colorbar = False
+ 
+     xs = []
+     ys = []


### PR DESCRIPTION
splot 1.1.3 [test geopandas 1.0.1]

**Destination channel:** defaults

### Links

- [PKG-6856]
- dev_url (pypi): https://github.com/pysal/splot/tree/v.1.1.3
- conda-forge: https://github.com/conda-forge/splot-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/splot/1.1.3
- pypi inspector: https://inspector.pypi.io/project/splot/1.1.3

### Depends on

- https://github.com/AnacondaRecipes/geopandas-feedstock/pull/11
- https://github.com/AnacondaRecipes/esda-feedstock/pull/3
- https://github.com/AnacondaRecipes/spreg-feedstock/pull/2
- https://github.com/AnacondaRecipes/pyogrio-feedstock/pull/1
- https://github.com/AnacondaRecipes/libpysal-feedstock/pull/6

### Changes

- bump build number
- ~we don't have to merge this PR, it is only used to build `libpysal 4.10` with `geopandas 1.0.1` on all platforms~
- we have to merge, there are a few changes
- `esda` is not updated for `libpysal 4.10` https://github.com/AnacondaRecipes/esda-feedstock/blob/master/recipe/meta.yaml#L22 and it will fail. Fixed in `esda 2.5.1` here https://github.com/pysal/esda/pull/272/files

[PKG-6856]: https://anaconda.atlassian.net/browse/PKG-6856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ